### PR TITLE
Feature: Make components fade into view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "nginx": "^1.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.4.3",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -2203,6 +2204,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz",
+      "integrity": "sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "nginx": "^1.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.3",
     "react-redux": "^8.0.5"
   },
   "devDependencies": {

--- a/src/components/about/about.tsx
+++ b/src/components/about/about.tsx
@@ -3,9 +3,7 @@ import profilePicture from "../../assets/wa.jpg";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLinkedin } from "@fortawesome/free-brands-svg-icons";
 
-interface Props {}
-
-const About = (props: Props) => {
+const About = () => {
   return (
     <Card
       className="flex items-center flex-row flex-wrap min-w-[600px] max-w-[800px] mx-auto mb-40"

--- a/src/components/greeting/greeting.tsx
+++ b/src/components/greeting/greeting.tsx
@@ -2,7 +2,7 @@ import Card from "../ui/card";
 
 const Greeting = () => {
   return (
-    <Card className="mx-auto px-8 min-h-[calc(100vh_-_400px)]">
+    <Card className="mx-auto px-8 min-h-[calc(100vh_-_400px)] duration-[1.5s]">
       <p className="text-2xl">Hi, my name is</p>
       <h1 className="text-8xl text-yellow-500">
         William Ahern<span className="text-white">.</span>

--- a/src/components/greeting/greeting.tsx
+++ b/src/components/greeting/greeting.tsx
@@ -2,7 +2,7 @@ import Card from "../ui/card";
 
 const Greeting = () => {
   return (
-    <Card className="mx-auto px-8 h-screen">
+    <Card className="mx-auto px-8 min-h-[calc(100vh_-_400px)]">
       <p className="text-2xl">Hi, my name is</p>
       <h1 className="text-8xl text-yellow-500">
         William Ahern<span className="text-white">.</span>

--- a/src/components/layout/content.tsx
+++ b/src/components/layout/content.tsx
@@ -5,7 +5,7 @@ import Greeting from "../greeting/greeting";
 
 const Content = () => {
   return (
-    <div className="flex flex-col mx-auto mt-60 w-full min-h-screen">
+    <div className="flex flex-col mx-auto mt-[400px] w-full min-h-screen">
       <Greeting />
       <About />
       <Experience />

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,16 +1,27 @@
 import { ReactNode } from "react";
+import { IntersectionOptions, useInView } from "react-intersection-observer";
 
 interface Props {
   children: ReactNode;
   id?: string;
   className?: string;
+  intersectionOptions?: IntersectionOptions;
 }
 
 const Card = (props: Props) => {
+  const intersectionOptions = props.intersectionOptions || {
+    threshold: 0.2,
+    triggerOnce: true,
+  };
+
+  const { ref, inView } = useInView(intersectionOptions);
+  const isIntersectingStyles = inView ? "opacity-100" : "opacity-0";
+
   return (
     <div
+      ref={ref}
       id={props.id}
-      className={`bg-inherit text-white rounded-md m-4 p-3 ${props.className}`}
+      className={`bg-inherit text-white rounded-md m-4 p-3 ${props.className} ${isIntersectingStyles} transition-opacity duration-[1s] ease-in-out}`}
     >
       {props.children}
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  mode: "jit",
   theme: {
     extend: {
       height: {


### PR DESCRIPTION
## Notes
## Context
I wanted components to nicely fade into view as soon as the user scrolls the component into their view port. To do this, I installed a package called [react-intersection-observer](https://www.npmjs.com/package/react-intersection-observer) that vends a React hook for detecting when a component enters/leaves the view port.

## Changes
- Adds react-intersection-observer package
- Updates Tailwind CSS config to use just-in-time (jit) mode so that the CSS `calc()` function can be used
- Updates how view port height is calculated between greeting and about components
- Updates Card component to leverage the react-intersection-observer hook