### PR TITLE
Fix: Determine correct screen size upon initialization

### DIFF
--- a/src/store/ui.tsx
+++ b/src/store/ui.tsx
@@ -13,11 +13,11 @@ export type SetThemeAction = {
 export type SetIsMobileAction = {
   type: string;
   payload: boolean;
-}
+};
 
 const initialState = {
   theme: Theme.Dark,
-  isMobile: true,
+  isMobile: window.innerWidth < 640,
 };
 
 const uiSlice = createSlice({
@@ -29,7 +29,7 @@ const uiSlice = createSlice({
     },
     setIsMobile(state, action: SetIsMobileAction) {
       state.isMobile = action.payload;
-    }
+    },
   },
 });
 


### PR DESCRIPTION
## Notes
### Context
Previously when the app was loaded, the `isMobile` state would be set to `true` by default with the assumption that the dispatcher call in`App.tsx` would update the state correctly. However, the dispatcher is only called upon a screen **_resize_**.

To fix this, we now determine the `isMobile` state upon initialization and then respond to screen resizing afterwards.

### Changes
- Update UI store initial state to to determine `isMobile` value upon loading