### PR TITLE
Fix: set trackVisibility to false

### DIFF
--- a/src/components/ui/scroll-down-button.tsx
+++ b/src/components/ui/scroll-down-button.tsx
@@ -12,7 +12,6 @@ interface Props {
 const ScrollDownButton = (props: Props) => {
   const intersectionOptions = props.intersectionOptions || {
     threshold: 1,
-    trackVisibility: true,
     rootMargin: "-80% 0px 0px 0px",
   };
 


### PR DESCRIPTION
## Notes
### Context
Having `trackVisibility` set to `true` in the `ScrollDownComponent`'s react intersection observer is breaking the app on some browsers. This property does not actually need to be set to true so removing it will not impact anything else.

### Changes
- Update `ScrollDownButton` component to default react intersection observer's `trackVisibility` property to false instead of true